### PR TITLE
added active_speaker global var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ dmypy.json
 /.vs/PyVTL/v16
 /.vs/CMake Overview
 /.vs
+
+# VS Code
+.vscode/


### PR DESCRIPTION
This introduces a global variable that tracks the loaded speaker file and a function that returns this variable.
This is an essential requirement for correctly initalizing the VTL API in case of multiprocessing with python.
Ideally the path could be directly accessed via the API but it seems that currently, the API does not save the path so it would require a larger change to the Backend, which  was avoided for now.

Further the PR makes the warning from calculate_tongeroot_automatically a normal log.info 
