### PR TITLE
Fix release versioning: derive version from the release tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,10 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Window 64 bit
-          - os: windows-latest
-            python: 39
-            platform_id: win_amd64
+          # Windows 64-bit
           - os: windows-latest
             python: 310
             platform_id: win_amd64
@@ -25,12 +22,15 @@ jobs:
             platform_id: win_amd64
           - os: windows-latest
             python: 312
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 313
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 314
             platform_id: win_amd64
 
-          # Linux 64 bit
-          - os: ubuntu-latest
-            python: 39
-            platform_id: manylinux_x86_64
+          # Linux 64-bit
           - os: ubuntu-latest
             python: 310
             platform_id: manylinux_x86_64
@@ -39,12 +39,15 @@ jobs:
             platform_id: manylinux_x86_64
           - os: ubuntu-latest
             python: 312
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 313
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 314
             platform_id: manylinux_x86_64
 
-          # MacOS arm64
-          - os: macos-14
-            python: 39
-            platform_id: macosx_arm64
+          # macOS arm64
           - os: macos-14
             python: 310
             platform_id: macosx_arm64
@@ -53,6 +56,12 @@ jobs:
             platform_id: macosx_arm64
           - os: macos-14
             python: 312
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 313
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 314
             platform_id: macosx_arm64
 
     steps:
@@ -60,11 +69,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0  # full history + tags for setuptools_scm (local/sdist path)
+
+      - name: Derive version from release tag
+        shell: bash
+        run: echo "PKG_VERSION=${TAG#v}" >> "$GITHUB_ENV"
+        env:
+          TAG: ${{ github.event.release.tag_name }}
 
       - name: Build wheels
         env:
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
-        uses: pypa/cibuildwheel@v2.19.1
+          # Inject the tag-derived version so setuptools_scm doesn't need git
+          # inside the (manylinux) build sandbox. CIBW_ENVIRONMENT forwards it
+          # into every build environment, including Linux containers.
+          CIBW_ENVIRONMENT: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VOCALTRACTLAB_CYTHON=${{ env.PKG_VERSION }}
+        uses: pypa/cibuildwheel@v4.1.0
 
       - uses: actions/upload-artifact@v4
         with:
@@ -80,6 +100,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0  # full history + tags for setuptools_scm
+
+      - name: Derive version from release tag
+        shell: bash
+        run: echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VOCALTRACTLAB_CYTHON=${TAG#v}" >> "$GITHUB_ENV"
+        env:
+          TAG: ${{ github.event.release.tag_name }}
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,11 @@ DEPENDENCIES = [
 
 setup_args = dict(
     name = 'vocaltractlab_cython',
-    version = '0.0.16',
+    # Version is derived from the git tag via setuptools_scm (use_scm_version
+    # below). Do NOT hard-code it here — a static value silently overrides the
+    # tag and ships the wrong version. In CI the release workflow injects
+    # SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VOCALTRACTLAB_CYTHON from the release
+    # tag so the build never depends on git inside the wheel sandboxes.
     author='Paul Krug',
     url='https://github.com/paul-krug/vocaltractlab-cython',
     description = 'Cython wrapper for VocalTractLabApi',
@@ -191,7 +195,10 @@ setup_args = dict(
     },
     include_package_data = True,
     use_scm_version = True,
-    setup_requires = [ 'setuptools_scm' ],
+    # setuptools_scm is declared in pyproject.toml [build-system].requires so
+    # PEP 517 front-ends (pip / build / cibuildwheel) install it correctly.
+    # The legacy setup_requires path is intentionally omitted: it triggers an
+    # easy_install egg fetch into .eggs/ that pulls a broken setuptools_scm.
     install_requires=DEPENDENCIES,
 )
 


### PR DESCRIPTION
The PyPI release shipped 0.0.16 (the previous version) and was rejected as a duplicate: setup.py hard-coded version='0.0.16' next to use_scm_version, and the publish workflow's shallow checkout hid the tag from setuptools_scm, so the stale literal won.

- setup.py: drop the hard-coded version and the legacy setup_requires (which easy_install-fetched a broken setuptools_scm into .eggs/). Version now comes solely from setuptools_scm.
- publish.yaml: derive the version from the release tag and inject it as SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VOCALTRACTLAB_CYTHON, forwarded into the build sandboxes via CIBW_ENVIRONMENT so the version never depends on git inside the manylinux container. fetch-depth: 0 keeps local/sdist builds reading the tag from git.
- Bump cibuildwheel v2.19.1 -> v4.1.0 and the wheel matrix to Python 3.10-3.14 (drop EOL 3.8/3.9), matching the test CI.

Verified locally: a PEP 517 build with the pretend-version env produces a 0.0.17 wheel.