### PR TITLE
Fix Windows wheel build: point delvewheel at the bundled backend DLL

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,6 +84,15 @@ jobs:
           # inside the (manylinux) build sandbox. CIBW_ENVIRONMENT forwards it
           # into every build environment, including Linux containers.
           CIBW_ENVIRONMENT: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VOCALTRACTLAB_CYTHON=${{ env.PKG_VERSION }}
+          # The backend DLL is built by setup.py and copied into
+          # vocaltractlab_cython/ (and shipped via package_data). delvewheel
+          # vendors the .pyd's dependencies but searches external paths only,
+          # so point it at that dir or it fails with "Unable to find library:
+          # vocaltractlabapi.dll" (newer delvewheel in cibuildwheel v4 is
+          # stricter than v2's, which found it implicitly).
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
+            delvewheel repair --add-path vocaltractlab_cython
+            -w {dest_dir} {wheel}
         uses: pypa/cibuildwheel@v4.1.0
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The release workflow's Windows wheel jobs fail in cibuildwheel's
`delvewheel repair` step (Linux and macOS are fine):

FileNotFoundError: Unable to find library: vocaltractlabapi.dll
cibuildwheel: Command delvewheel repair ... failed with code 1.



The compile and link succeed — the failure is only in the post-build
DLL-vendoring step. `setup.py` builds the backend `VocalTractLabApi.dll`,
copies it into `vocaltractlab_cython/`, and ships it via `package_data`,
so the DLL is already inside the wheel. But `delvewheel` resolves the
`.pyd`'s dependencies by searching external paths and doesn't look
inside the wheel's own package, so it can't find the bundled DLL. (The
older `delvewheel` in cibuildwheel v2.19.1 located it implicitly; the
newer one shipped with v4.x is stricter — this surfaced when the build
matrix was bumped to cibuildwheel v4.1.0 / Python 3.10–3.14.)

Fix: tell `delvewheel` where the DLL lives via a Windows-only repair
command override:

CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
delvewheel repair --add-path vocaltractlab_cython -w {dest_dir} {wheel}



CI/build-only change; no package code changes.